### PR TITLE
Adicionando novos canais de live no youtube

### DIFF
--- a/awesome_yt.md
+++ b/awesome_yt.md
@@ -5,10 +5,14 @@
 # Python
 
 [Live de Python](https://www.youtube.com/user/mendesesduardo)
+[Mario Filho](https://www.youtube.com/user/marionefilho)
+[Spacedevs](https://www.youtube.com/channel/UCedHFDY78egBPEJXL2d8OiQ)
+
 
 # DevOps
 
 [Punk do Devops](https://www.youtube.com/c/PunkdoDevOps)
+[Linux Tips] (https://www.youtube.com/user/linuxtipscanal)
 
 # Infrastructure
 


### PR DESCRIPTION
Adicionando novos canais na lista de lives do youtube.

Foi adicionado o canal do spacedevs e mario filho na lista de python e o canal do linux tips na lista de devops.