### PR TITLE
livedepython mudou para dunossauro

### DIFF
--- a/awesome_twitch.md
+++ b/awesome_twitch.md
@@ -279,7 +279,7 @@
 
 [karlamag](https://www.twitch.tv/karlamag)
 
-[livedepython](https://www.twitch.tv/livedepython)
+[dunossauro](https://www.twitch.tv/dunossauro)
 
 [nceder](https://www.twitch.tv/nceder)
 


### PR DESCRIPTION
A live do Eduardo Mendes, que era https://www.twitch.tv/livedepython mudou para https://www.twitch.tv/dunossauro.

O twit de quando ele conseguiu mudar o nick na twitch: https://twitter.com/dunossauro/status/1318736414025154562